### PR TITLE
Added missing MPFR check, to fix conflicting type declaration error

### DIFF
--- a/ext/ruby_gmp.h
+++ b/ext/ruby_gmp.h
@@ -265,7 +265,11 @@ extern VALUE r_gmpf_set_prec_raw(VALUE self, VALUE arg);
 
 // Converting Floats
 extern VALUE r_gmpf_to_d(VALUE self);
+#ifdef MPFR
 extern VALUE r_gmpf_to_s(int argc, VALUE *argv, VALUE self);
+#else
+extern VALUE r_gmpf_to_s(VALUE self);
+#endif
 
 // Float Arithmetic
 #ifndef MPFR


### PR DESCRIPTION
Hi, it seems you may have forgotten to update the header declaration for r_gmpf_to_s when you extended the interface variant for MPFR. It got the compiler angry when compiling on a non-MPFR system.
